### PR TITLE
Revert "[BUG FIX] TravisCI : brew KO these days ?!..."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,12 +49,12 @@ matrix:
       python: 3.3
 
     # Mac OS.
-    #- os: osx
-    #  osx_image: xcode9
-    #  sudo: required
-    #  env:
-    #    - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7 && FC=gfortran-7"
-    #  python: 2.7
+    - os: osx
+      osx_image: xcode9
+      sudo: required
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7 && FC=gfortran-7"
+      python: 2.7
 
 virtualenv:
 
@@ -71,9 +71,9 @@ install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get                                                                 update;       fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -y --allow-unauthenticated -o Dpkg::Options::="--force-confdef" upgrade;      fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -y --allow-unauthenticated -o Dpkg::Options::="--force-confdef" dist-upgrade; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    cask uninstall oclint;                                             fi # conflicts with gcc.
-  - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    update;                                                            fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    upgrade;                                                           fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    cask uninstall oclint || true;                                     fi # conflicts with gcc.
+  - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    update                || true;                                     fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    upgrade               || true;                                     fi
   - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    list -1 | while read line; do brew unlink             $line; done; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    list -1 | while read line; do brew   link --overwrite $line; done; fi
 
@@ -90,17 +90,17 @@ install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install diffutils findutils;                       fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install libbz2-dev;                                fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install python-minimal python-tk;                  fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    install wget gzip;            fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    install git;                  fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    install gcc;                  fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    install openmpi;              fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    install boost-mpi;            fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    install lapack;               fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    install cmake;                fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    install autoconf automake;    fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    install diffutils findutils;  fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    install bzip2;                fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    install python@2 --with-tcl-tk;                                        fi # PETSc / SLEPc don't support python3.
+  - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    install wget gzip              || true; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    install git                    || true; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    install gcc                    || true; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    install openmpi                || true; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    install boost-mpi              || true; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    install lapack                 || true; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    install cmake                  || true; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    install autoconf automake      || true; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    install diffutils findutils    || true; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    install bzip2                  || true; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    install python@2 --with-tcl-tk || true;                                fi # PETSc / SLEPc don't support python3.
   - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then      brew    link --overwrite --force python@2;                                     fi # PETSc / SLEPc don't support python3.
   - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then ls -al /usr/local/opt/python@2/bin/python*;                                         fi # PETSc / SLEPc don't support python3.
   - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then sudo ln -fs /usr/local/opt/python@2/bin/python2 /usr/local/opt/python@2/bin/python; fi # PETSc / SLEPc don't support python3.


### PR DESCRIPTION
This reverts commit 5239905a0f36a596d9978920552febf952e513e0
that should be uncommented/reverted as soon as possible...

Homebrew returns non-zero when install / upgrade detects a
version which is already fine.

TravisCI has updated the osx VMs: before that, software versions
were older. There was no problem... brew install / update / upgrade
returned 0. Now, it returns 1...

Solution : use brew || true instead of brew.

## Pull request purpose: fixing issue #xx ? enhancement ? new feature ?...

## Detailed changes proposed in this pull request

-
-
-

